### PR TITLE
Fix humidity text overlapping other modules

### DIFF
--- a/MMM-Nest.css
+++ b/MMM-Nest.css
@@ -35,11 +35,16 @@
   width: 0;
 }
 
+.MMM-Nest .thermContainer {
+  width: 120px;
+}
+
 .MMM-Nest .humidityText {
-  position:absolute;
   font-size:large;
-  top: 60%;
   width: 100%;
+  width: 120px;
+  text-align: center;
+  padding-top: 5px;
 }
 
 .MMM-Nest .nameText {
@@ -94,9 +99,6 @@
 }
 
 .MMM-Nest .humidityText {
-  top: 0;
-  display: block;
-  margin-top: 135px;
   line-height: 1;
 }
 
@@ -172,8 +174,8 @@
 }
 
 .MMM-Nest .greenBoth {
- position: relative;
- top: -124px;
+ position: absolute;
+ top: -5px;
  left: -4px;
  border: 4px solid #11d611;
  border-radius: 50%;
@@ -210,8 +212,8 @@
 }
 
 .MMM-Nest .yellowBoth {
- position: relative;
- top: -124px;
+ position: absolute;
+ top: -5px;
  left: -4px;
  border: 4px solid #ffbe00;
  border-radius: 50%;
@@ -238,8 +240,8 @@
 }
 
 .MMM-Nest .redBoth {
- position: relative;
- top: -124px;
+ position: absolute;
+ top: -5px;
  left: -4px;
  border: 4px solid #d92a00;
  border-radius: 50%;

--- a/MMM-Nest.js
+++ b/MMM-Nest.js
@@ -241,7 +241,7 @@ Module.register("MMM-Nest",{
 		   	var fan = document.createElement("img");
 		   	fan.src = this.file("icons/fan-icon.png");
 		   	fan.className = "fanIcon";
-		   	wrapper.appendChild(fan);
+		   	circle.appendChild(fan);
 		   }
 		 } if (this.config.displayMode === "both") {
 		   var protectRing = document.createElement("div");

--- a/MMM-Nest.js
+++ b/MMM-Nest.js
@@ -199,35 +199,38 @@ Module.register("MMM-Nest",{
 		} else {
 		 if (this.config.displayMode !== "protect" ) {
 		   //var theName = document.createElement("div");
+		   wrapper.className = "thermContainer";
+		   var circle = document.createElement("div");
 		   if (this.hvacMode[this.chosenNest] === 'heat-cool') {
-			wrapper.id = "circle";
-			wrapper.className = this.hvacState[this.chosenNest] + "HC";
-			wrapper.innerHTML = this.targetTempL[this.chosenNest] + " &bull; " + this.targetTempH[this.chosenNest];
+			circle.id = "circle";
+			circle.className = this.hvacState[this.chosenNest] + "HC";
+			circle.innerHTML = this.targetTempL[this.chosenNest] + " &bull; " + this.targetTempH[this.chosenNest];
 		   } else {
-			wrapper.id = "circle";
-			wrapper.className = this.hvacState[this.chosenNest];
-			wrapper.innerHTML = this.targetTemp[this.chosenNest];
+			circle.id = "circle";
+			circle.className = this.hvacState[this.chosenNest];
+			circle.innerHTML = this.targetTemp[this.chosenNest];
 		   }
 		   var theTemp = document.createElement("div");
 		   if (this.hvacState[this.chosenNest] === "cooling") {
 			theTemp.innerHTML = this.ambientTemp[this.chosenNest];
 			theTemp.className = "coolingText";
-			wrapper.appendChild(theTemp);
+			circle.appendChild(theTemp);
 		   } else if ( this.hvacState === "heating") {
 			theTemp.innerHTML = this.ambientTemp[this.chosenNest];
 			theTemp.className = "heatingText";
-			wrapper.appendChild(theTemp);
+			circle.appendChild(theTemp);
 		   } else if ( this.hvacMode !== 'heat-cool') {
 			if (parseInt(this.ambientTemp[this.chosenNest]) < parseInt(this.targetTemp[this.chosenNest])) {
 			   theTemp.innerHTML = this.ambientTemp[this.chosenNest];
 			   theTemp.className = "heatingText";
-			   wrapper.appendChild(theTemp);
+			   circle.appendChild(theTemp);
 		   	} else if (parseInt(this.ambientTemp[this.chosenNest]) > parseInt(this.targetTemp[this.chosenNest])) {
 		 	   theTemp.innerHTML = this.ambientTemp[this.chosenNest];
 			   theTemp.className = "coolingText";
-			   wrapper.appendChild(theTemp);
+			   circle.appendChild(theTemp);
 		   	}
 		   }
+		   wrapper.appendChild(circle);
 
 		   var theHumidity = document.createElement("div");
 		   theHumidity.innerHTML = this.humidity[this.chosenNest] + "%";
@@ -246,8 +249,9 @@ Module.register("MMM-Nest",{
 		   wrapper.appendChild(protectRing);
 
 		 } if (this.config.displayMode === "protect") {
-		   wrapper.id = "ring";
-		   wrapper.className = this.uiColor[this.chosenProt] + "Ring";
+		   var ring = document.createElement("div");
+		   ring.id = "ring";
+		   ring.className = this.uiColor[this.chosenProt] + "Ring";
 		   if (this.uiColor[this.chosenProt] !== "green") {
 			var batteryIcon = document.createElement("img");
 			var displayText = document.createElement("p");
@@ -255,23 +259,24 @@ Module.register("MMM-Nest",{
 
 			if(this.coState[this.chosenProt] == "emergency") {
 			   displayText.innerHTML = "CO";
-			   wrapper.appendChild(displayText);
+			   ring.appendChild(displayText);
 			} else if (this.smokeState[this.chosenProt] == "emergency") {
                            displayText.innerHTML = "Smoke";
-			   wrapper.appendChild(displayText);
+			   ring.appendChild(displayText);
                         } else if (this.coState[this.chosenProt] == "warning") {
                            displayText.innerHTML = "CO";
-			   wrapper.appendChild(displayText);
+			   ring.appendChild(displayText);
                         } else if (this.smokeState[this.chosenProt] == "warning") {
                            displayText.innerHTML = "Smoke";
-			   wrapper.appendChild(displayText);
+			   ring.appendChild(displayText);
                         } else if (this.batteryHealth[this.chosenProt] == "replace") {
                            batteryIcon.src = this.file("icons/battery-icon.png");
                            batteryIcon.className = "batteryIcon";
-                           wrapper.appendChild(batteryIcon);
+                           ring.appendChild(batteryIcon);
 			}
 		   }
 
+		   wrapper.appendChild(ring);
 		 }
 		}
 		


### PR DESCRIPTION
This moves the main "circle" display into its own div so the humidity text can
sit beneath it, and converts a lot of the absolute positioning into normal
positioning to let the browser's layout engine encompass everything correctly
into the parent "module-content" div.

Tested in visual and list modes; left and right sides; and in "nest", "protect",
and "both" display modes.

Fixes https://github.com/mochman/MMM-Nest/issues/18